### PR TITLE
✅ Tests for Vector3

### DIFF
--- a/src/main/kotlin/com/github/shatteredsuite/core/math/vector/Vector3.kt
+++ b/src/main/kotlin/com/github/shatteredsuite/core/math/vector/Vector3.kt
@@ -46,6 +46,8 @@ open class Vector3<T : Number>(
         }
     }
 
+    operator fun unaryMinus(): Vector3<T> = negate()
+
     infix fun dot(other: Vector3<*>): T {
         return with(context) {
             _x * other._x + _y * other._y + _z * other._z

--- a/src/test/kotlin/com/github/shatteredsuite/core/math/TestVector3.kt
+++ b/src/test/kotlin/com/github/shatteredsuite/core/math/TestVector3.kt
@@ -61,6 +61,17 @@ class TestVector3 {
     }
 
     @Test
+    fun `should calculate unary minus properly`() {
+        val v = Vector3(DoubleContext, 3.0, 4.0, 5.0)
+
+        val actual = -v
+        val expected = Vector3(DoubleContext, -3.0, -4.0, -5.0)
+
+        assertVectorCloseTo(actual, expected)
+    }
+
+
+    @Test
     fun `should compute dot product properly`() {
         val v1 = Vector3(DoubleContext, 5.0, 1.0, 1.0)
         val v2 = Vector3(DoubleContext, 1.0, 0.0, 1.0)


### PR DESCRIPTION
- This PR add most of the tests for `Vector3`. Please note that tests for swizzling are not included. 
- This adds support for unaryMinus for `Vector3`
   ```kotlin
    val minusV: Vector3<Double> = -v // this is valid now
    ```

Closes #27 